### PR TITLE
Sanitize country hashtag spacing

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -48,14 +48,14 @@ suspend fun main() {
                 editMessageCaption(
                     chatId = it.chat.id,
                     messageId = it.messageId,
-                    entities = msgSources + buildEntities { regular("\n\n#${getCurrentCountry()} ${getCityName()}") }
+                    entities = msgSources + buildEntities { regular("\n\n#${getCurrentCountry()?.replace(" ", "_")} ${getCityName()}") }
                 )
             } else {
                 val msgSources = it.entities ?: emptyList()
                 editMessageText(
                     chatId = it.chat.id,
                     messageId = it.messageId,
-                    entities = msgSources + buildEntities { regular("\n\n#${getCurrentCountry()} ${getCityName()}") }
+                    entities = msgSources + buildEntities { regular("\n\n#${getCurrentCountry()?.replace(" ", "_")} ${getCityName()}") }
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Replace spaces with underscores in country hashtags to avoid broken tags

## Testing
- `./gradlew test` *(fails: com.github.centralhardware:ktgbotapi-commons:28.0.0 requires JDK 24)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4c965c58832586c6d0c74c5a953b