### PR TITLE
Handle missing country codes gracefully

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -84,7 +84,17 @@ suspend fun main() {
     }
 }
 
-fun getCountryCode(country: String): String = CountryCode.findByName("(?i)" + country.replace("&", "and").replace("vietnam", "Viet Nam"))[0].name
+fun getCountryCode(country: String): String {
+    val search = "(?i)" + country
+        .replace("&", "and")
+        .replace("vietnam", "Viet Nam")
+
+    return CountryCode.findByName(search)
+        .firstOrNull()
+        ?.name
+        // Use first two letters as a sensible default when the lookup fails
+        ?: country.take(2).padEnd(2, 'X')
+}
 
 fun extractCountryCode(title: String): String {
     val emoji = EmojiManager.extractEmojis(title).first()
@@ -92,7 +102,7 @@ fun extractCountryCode(title: String): String {
 }
 
 fun countryCodeToEmoji(country: String): String {
-    val upperCaseCountryCode = getCountryCode(country).uppercase()
+    val upperCaseCountryCode = getCountryCode(country).uppercase().take(2).padEnd(2, 'X')
 
     val firstChar = upperCaseCountryCode[0] - 'A' + 0x1F1E6
     val secondChar = upperCaseCountryCode[1] - 'A' + 0x1F1E6


### PR DESCRIPTION
## Summary
- Handle cases where country lookup fails by using a safe fallback
- Ensure emoji conversion works even when country codes are unavailable

## Testing
- `./gradlew test` *(fails: Dependency resolution is looking for a library compatible with JVM runtime version 21, but ktgbotapi-commons:28.0.0 is only compatible with JVM runtime version 24 or newer)*
- `apt-get install -y openjdk-24-jdk` *(fails: Unable to locate package openjdk-24-jdk)*

------
https://chatgpt.com/codex/tasks/task_e_68bd51741408832599f670ad37c99919