### PR TITLE
Update to tgbotapi 34.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,13 +12,13 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val ktgbotapiVersion = "33.1.0"
+val ktgbotapiVersion = "34.0.0"
 val ktorVersion = "3.5.0"
 val clickhouseVersion = "0.9.8"
 
 dependencies {
     implementation("dev.inmo:tgbotapi:$ktgbotapiVersion")
-    implementation("com.github.centralhardware:ktgbotapi-commons:8b9e69dd")
+    implementation("com.github.centralhardware:ktgbotapi-commons:eb3d7671")
 
     implementation("com.clickhouse:clickhouse-jdbc:$clickhouseVersion")
     implementation("com.clickhouse:clickhouse-http-client:$clickhouseVersion")


### PR DESCRIPTION
Bumps tgbotapi to 34.0.0 and ktgbotapi-commons to `eb3d7671` (which merged the 34.0.0 upgrade). Renamed `CommonMessage` → `ChatContentMessage` where needed. Builds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)