### PR TITLE
Fix country sessionization to split on calendar gaps

### DIFF
--- a/src/main/kotlin/DatabaseService.kt
+++ b/src/main/kotlin/DatabaseService.kt
@@ -196,8 +196,12 @@ object DatabaseService {
                         with_sessions AS (
                             SELECT
                                 *,
-                                dense_rank() OVER (ORDER BY day) -
-                                dense_rank() OVER (PARTITION BY country ORDER BY day) AS session_id
+                                -- Island by calendar adjacency: a run of consecutive
+                                -- same-country days shares one anchor date, and any gap
+                                -- > 1 day starts a new session. This prevents merging
+                                -- non-contiguous visits (e.g. separate Egypt trips in
+                                -- 2011/2012/2014 with nothing logged in between).
+                                day - toIntervalDay(row_number() OVER (PARTITION BY country ORDER BY day)) AS session_id
                             FROM data
                         )
                     SELECT
@@ -235,8 +239,12 @@ object DatabaseService {
                         with_sessions AS (
                             SELECT
                                 *,
-                                row_number() OVER (ORDER BY day) -
-                                row_number() OVER (PARTITION BY country ORDER BY day) AS session_id
+                                -- Island by calendar adjacency (see getCountrySessions):
+                                -- consecutive same-country days share an anchor date; any
+                                -- gap > 1 day starts a new session, so the "current"
+                                -- session is only the latest unbroken run, not a span
+                                -- merged across earlier visits.
+                                day - toIntervalDay(row_number() OVER (PARTITION BY country ORDER BY day)) AS session_id
                             FROM data
                         ),
                         sessions_grouped AS (


### PR DESCRIPTION
## The bug

Both `getCountrySessions()` (feeds the ICS calendar) and `getCurrentCountryLength()` (feeds `Current country: <name> <days>` in the stat command) used a rank-difference gaps-and-islands trick:

```sql
rank() OVER (ORDER BY day) - rank() OVER (PARTITION BY country ORDER BY day)
```

That difference only changes when **another country's day interleaves** in the global day ordering — it completely ignores calendar gaps. For sparse historical data where nothing is logged between two visits to the same country, separate trips collapse into one giant session:

- Egypt visits in 2011, 2012 and 2014 (nothing logged in between) → one session `2011-09-27 → 2014-12-09` (1169 days).
- Thailand 2015 + 2018 → one `2015-09-16 → 2018-12-08` span.

This is why the ICS export shows multi-year phantom stays, and why the "current country" length can span across earlier visits.

## The fix

Island by actual calendar adjacency, per country:

```sql
day - toIntervalDay(row_number() OVER (PARTITION BY country ORDER BY day))
```

A run of consecutive same-country days shares a stable anchor date (`day − rowNumber` is constant across a contiguous run); any gap > 1 day shifts the anchor and starts a new session. Non-contiguous visits are therefore never merged, and the "current country" resolves to only the latest unbroken run.

`getCountryStats()` (distinct-day counts) was already correct and is untouched.

## Verification

Distinct-day counts (which the fix now matches on a per-session basis) line up with the known totals — e.g. Egypt = 16 (2011) + 11 (2012) + 12 (2014) = 39 days across three sessions instead of one 1169-day span; Thailand's old trips split into 2015 and 2018 sessions. Pure SQL-string change; no Kotlin structure touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)