### PR TITLE
Only split country sessions on real departures, not logging gaps

### DIFF
--- a/src/main/kotlin/DatabaseService.kt
+++ b/src/main/kotlin/DatabaseService.kt
@@ -193,16 +193,53 @@ object DatabaseService {
                             WHERE country != ''
                             GROUP BY day, country
                         ),
+                        all_days AS (
+                            SELECT
+                                day,
+                                lagInFrame(day) OVER (
+                                    ORDER BY day ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                                ) AS prev_any
+                            FROM (SELECT DISTINCT day FROM data)
+                        ),
+                        marked AS (
+                            SELECT
+                                d.country AS country,
+                                d.day AS day,
+                                lagInFrame(d.day) OVER (
+                                    PARTITION BY d.country ORDER BY d.day
+                                    ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                                ) AS prev_same,
+                                a.prev_any AS prev_any
+                            FROM data AS d
+                            INNER JOIN all_days AS a ON d.day = a.day
+                        ),
                         with_sessions AS (
                             SELECT
-                                *,
-                                -- Island by calendar adjacency: a run of consecutive
-                                -- same-country days shares one anchor date, and any gap
-                                -- > 1 day starts a new session. This prevents merging
-                                -- non-contiguous visits (e.g. separate Egypt trips in
-                                -- 2011/2012/2014 with nothing logged in between).
-                                day - toIntervalDay(row_number() OVER (PARTITION BY country ORDER BY day)) AS session_id
-                            FROM data
+                                country,
+                                day,
+                                -- A "session" is one continuous physical stay. A new
+                                -- session starts only on a real departure:
+                                --   * first day logged for the country, or
+                                --   * another country was logged in the gap (the previous
+                                --     logged day of ANY country is later than the previous
+                                --     same-country day), or
+                                --   * a long gap with nothing logged at all (> 30 days) —
+                                --     a genuine absence, e.g. sparse historical revisits
+                                --     like the separate Egypt trips in 2011/2012/2014.
+                                -- A 1-2 day logging gap within a stay is NOT a break, so
+                                -- continuous stays no longer fragment into tiny sessions.
+                                sum(
+                                    if(
+                                        prev_same = toDate(0)
+                                        OR prev_any > prev_same
+                                        OR dateDiff('day', prev_same, day) > 30,
+                                        1, 0
+                                    )
+                                ) OVER (
+                                    PARTITION BY country ORDER BY day
+                                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                                ) AS session_id
+                            FROM marked
                         )
                     SELECT
                         country,
@@ -236,16 +273,47 @@ object DatabaseService {
                             WHERE country != ''
                             GROUP BY day, country
                         ),
+                        all_days AS (
+                            SELECT
+                                day,
+                                lagInFrame(day) OVER (
+                                    ORDER BY day ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                                ) AS prev_any
+                            FROM (SELECT DISTINCT day FROM data)
+                        ),
+                        marked AS (
+                            SELECT
+                                d.country AS country,
+                                d.day AS day,
+                                lagInFrame(d.day) OVER (
+                                    PARTITION BY d.country ORDER BY d.day
+                                    ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+                                ) AS prev_same,
+                                a.prev_any AS prev_any
+                            FROM data AS d
+                            INNER JOIN all_days AS a ON d.day = a.day
+                        ),
                         with_sessions AS (
                             SELECT
-                                *,
-                                -- Island by calendar adjacency (see getCountrySessions):
-                                -- consecutive same-country days share an anchor date; any
-                                -- gap > 1 day starts a new session, so the "current"
-                                -- session is only the latest unbroken run, not a span
-                                -- merged across earlier visits.
-                                day - toIntervalDay(row_number() OVER (PARTITION BY country ORDER BY day)) AS session_id
-                            FROM data
+                                country,
+                                day,
+                                -- Same session rule as getCountrySessions: a new session
+                                -- starts only on a real departure (another country logged
+                                -- in the gap, or a > 30-day gap with nothing logged), not
+                                -- on a 1-2 day logging gap. So the "current" session is the
+                                -- latest continuous stay, not fragmented by missing days.
+                                sum(
+                                    if(
+                                        prev_same = toDate(0)
+                                        OR prev_any > prev_same
+                                        OR dateDiff('day', prev_same, day) > 30,
+                                        1, 0
+                                    )
+                                ) OVER (
+                                    PARTITION BY country ORDER BY day
+                                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                                ) AS session_id
+                            FROM marked
                         ),
                         sessions_grouped AS (
                             SELECT


### PR DESCRIPTION
## Follow-up to #220

The calendar-adjacency fix in #220 over-corrected: it started a new session on **any** gap > 1 day, so a single missing-log day inside a continuous stay fragmented it. Session counts blew up:

| country | before #220 | after #220 | this PR |
|---|---|---|---|
| Montenegro | 17 | **30** | 17 |
| Indonesia | 2 | **3** | 2 |
| Malaysia | 10 | **12** | 10 |
| Egypt | 1 | 3 | 3 |
| Thailand | 4/5 | 6 | 6 |

e.g. the current Indonesia stay split at a one-day hole (`2026-05-11→06-24` + `06-25→07-05`), so "current country since …" pointed at the wrong date.

## Rule

Distinguish a real departure from a logging gap. A new session starts only when:

* it's the first logged day for the country, **or**
* another country was logged during the gap — detected as `prev_any > prev_same`: the previous logged day of *any* country is later than the previous *same-country* day, so a trip elsewhere interleaves, **or**
* the gap has nothing logged at all for **> 30 days** — a genuine absence, which is what separates sparse historical revisits (Egypt 2011 / 2012 / 2014 have nothing logged in between, hundreds of days apart).

A 1–2 day logging gap within a stay no longer breaks the session. Applied to both `getCountrySessions` (ICS) and `getCurrentCountryLength`.

## Verification

Simulated on the reconstructed per-day presence: total sessions **95 → 98** — i.e. exactly the three legitimate historical splits (Egypt +2, Thailand +1) and none of the spurious recent fragmentation. Per-country counts match the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)