### PR TITLE
Add configurable locality overrides

### DIFF
--- a/src/main/kotlin/LocalityOverrideManager.kt
+++ b/src/main/kotlin/LocalityOverrideManager.kt
@@ -1,0 +1,53 @@
+import kotliquery.queryOf
+import kotliquery.sessionOf
+
+object LocalityOverrideManager {
+
+    fun addOverride(from: String, to: String) {
+        sessionOf(PostgresService.dataSource).use { session ->
+            session.update(
+                queryOf(
+                    """
+                    INSERT INTO locality_overrides (from_locality, to_locality)
+                    VALUES (?, ?)
+                    ON CONFLICT (from_locality) DO UPDATE SET to_locality = EXCLUDED.to_locality
+                    """.trimIndent(),
+                    from,
+                    to
+                )
+            )
+        }
+    }
+
+    fun removeOverride(from: String): Boolean {
+        return sessionOf(PostgresService.dataSource).use { session ->
+            session.update(
+                queryOf("DELETE FROM locality_overrides WHERE from_locality = ?", from)
+            ) > 0
+        }
+    }
+
+    fun getOverrides(): List<Pair<String, String>> {
+        return sessionOf(PostgresService.dataSource).use { session ->
+            session.run(
+                queryOf("SELECT from_locality, to_locality FROM locality_overrides ORDER BY from_locality")
+                    .map { Pair(it.string("from_locality"), it.string("to_locality")) }
+                    .asList
+            )
+        }
+    }
+
+    /**
+     * Returns the override target if geocoding produced a [locality] that matches a
+     * configured `from` value, otherwise returns [locality] unchanged.
+     */
+    fun resolve(locality: String): String {
+        return sessionOf(PostgresService.dataSource).use { session ->
+            session.run(
+                queryOf("SELECT to_locality FROM locality_overrides WHERE from_locality = ?", locality)
+                    .map { it.string("to_locality") }
+                    .asSingle
+            )
+        } ?: locality
+    }
+}

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,6 +1,7 @@
 import ChannelManager.registerHashtagHandler
 import ChannelManager.updateChannelTitle
 import commands.registerMapCommand
+import commands.registerOverrideCommands
 import commands.registerStatCommand
 import commands.registerTagCommands
 import dev.inmo.krontab.doInfinity
@@ -29,13 +30,17 @@ suspend fun main() {
             BotCommand("addtag", "add temporary tag"),
             BotCommand("removetag", "remove temporary tag"),
             BotCommand("tags", "list active tags"),
-            BotCommand("cleartags", "remove all tags")
+            BotCommand("cleartags", "remove all tags"),
+            BotCommand("addoverride", "add locality override (from -> to)"),
+            BotCommand("removeoverride", "remove locality override"),
+            BotCommand("overrides", "list locality overrides")
         )
 
         registerHashtagHandler(Config.CHANNEL_ID)
         registerStatCommand()
         registerMapCommand()
         registerTagCommands()
+        registerOverrideCommands()
     }.second.join()
 
 }

--- a/src/main/kotlin/WebService.kt
+++ b/src/main/kotlin/WebService.kt
@@ -111,7 +111,7 @@ object WebService {
                     body.acc,
                     body.vac,
                     body.conn,
-                    body.locality,
+                    LocalityOverrideManager.resolve(body.locality),
                     body.ghash,
                     body.p,
                     body.addr,

--- a/src/main/kotlin/commands/OverrideCommand.kt
+++ b/src/main/kotlin/commands/OverrideCommand.kt
@@ -1,0 +1,53 @@
+package commands
+
+import LocalityOverrideManager
+import dev.inmo.tgbotapi.extensions.api.send.reply
+import dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContext
+import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onCommand
+import dev.inmo.tgbotapi.extensions.behaviour_builder.triggers_handling.onCommandWithArgs
+
+private const val SEPARATOR = "->"
+
+fun BehaviourContext.registerOverrideCommands() {
+    onCommandWithArgs("addoverride") { message, args ->
+        val parts = args.joinToString(" ").split(SEPARATOR).map { it.trim() }
+        if (parts.size != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            reply(
+                message,
+                "Usage: /addoverride <from> $SEPARATOR <to>\n" +
+                    "Example: /addoverride Muang Chiang Mai $SEPARATOR Chiang Mai"
+            )
+            return@onCommandWithArgs
+        }
+
+        LocalityOverrideManager.addOverride(parts[0], parts[1])
+        reply(message, "Override added: ${parts[0]} → ${parts[1]}")
+    }
+
+    onCommandWithArgs("removeoverride") { message, args ->
+        val from = args.joinToString(" ").trim()
+        if (from.isEmpty()) {
+            reply(message, "Usage: /removeoverride <from>")
+            return@onCommandWithArgs
+        }
+
+        if (LocalityOverrideManager.removeOverride(from)) {
+            reply(message, "Override removed")
+        } else {
+            reply(message, "Override not found")
+        }
+    }
+
+    onCommand("overrides") { message ->
+        val overrides = LocalityOverrideManager.getOverrides()
+        if (overrides.isEmpty()) {
+            reply(message, "No locality overrides")
+        } else {
+            reply(
+                message,
+                "Locality overrides:\n" +
+                    overrides.joinToString("\n") { (from, to) -> "$from → $to" }
+            )
+        }
+    }
+}

--- a/src/main/resources/db/postgres/migration/V2__locality_overrides.sql
+++ b/src/main/resources/db/postgres/migration/V2__locality_overrides.sql
@@ -1,0 +1,4 @@
+CREATE TABLE locality_overrides (
+    from_locality TEXT PRIMARY KEY,
+    to_locality   TEXT NOT NULL
+);


### PR DESCRIPTION
## What

Geocoding sometimes returns a locality name that differs from the one we want stored (e.g. `Muang Chiang Mai` vs `Chiang Mai`). This adds a runtime-editable `from -> to` override map that is applied to each incoming locality before it is persisted.

## How

- **Postgres migration** `V2__locality_overrides.sql` — table `locality_overrides (from_locality PK, to_locality)`, stored alongside tags.
- **`LocalityOverrideManager`** — `add`/`remove`/`getOverrides` + `resolve(locality)`; upserts on the `from` key.
- **`WebService`** — applies `resolve()` to `body.locality` right before `DatabaseService.save`. If geocoding's locality matches a `from`, `to` is stored; otherwise it passes through unchanged.
- **Bot commands** (registered + advertised via `setMyCommands`):
  - `/addoverride <from> -> <to>` — e.g. `/addoverride Muang Chiang Mai -> Chiang Mai`
  - `/removeoverride <from>`
  - `/overrides` — list current mappings

`->` is used as the separator because locality names contain spaces.

## Notes

- Only affects new location writes; existing rows are untouched.
- `compileKotlin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)